### PR TITLE
ft(Healthfacilities):Add midwives-chews-ambulances

### DIFF
--- a/src/pages/HealthFacilities.js
+++ b/src/pages/HealthFacilities.js
@@ -111,6 +111,15 @@ export default class HealthFacilities extends React.Component {
     return row.sub_county &&
     row.sub_county[item]
   }
+  getMidwives(cell,row){
+    return row.midwife
+  }
+  getChews(cell, row){
+    return row.chew
+  }
+  getAmbulances(cell, row){
+    return row.ambulance
+  }
 
   search(event) {
     this.setState({ search: event.target.value });
@@ -297,6 +306,8 @@ export default class HealthFacilities extends React.Component {
                       hidden={this.state.manageColomns.midwives}
                       dataSort={true}
                       dataField='midwives'
+                      dataFormat={(cell,row)=>this.getMidwives(cell, row)}
+                      csvFormat={(cell,row)=>this.getMidwives(cell, row)}
                     >
                       Midwives
                     </TableHeaderColumn>
@@ -304,6 +315,8 @@ export default class HealthFacilities extends React.Component {
                       hidden={this.state.manageColomns.vhts}
                       dataSort={true}
                       dataField='vhts'
+                      dataFormat={(cell, row)=>this.getChews(cell,row)}
+                      csvFormat={(cell,row)=>this.getChews(cell,row)}
                     >
                       Chews
                     </TableHeaderColumn>
@@ -327,6 +340,8 @@ export default class HealthFacilities extends React.Component {
                       hidden={this.state.manageColomns.ambulances}
                       dataSort={true}
                       dataField='ambulances'
+                      dataFormat={(cell,row)=>this.getAmbulances(cell, row)}
+                      csvFormat={(cell,row)=>this.getAmbulances(cell,row)}
                     >
                       Ambulances
                     </TableHeaderColumn>


### PR DESCRIPTION
**What does this PR do?**
Adds the number of midwives, chews, ambulances to the Health facilities field
**Description of the task to be completed.**
The number of midwives, chews, ambulances should be shown in the respective columns under Health facilities
**How should this be manually tested?**

- Pull the changes
- Checkout to **ft(Healthfacilities):add-midwives-chews-ambulances** branch
- Run the server on localhost
- Visit this url **http://localhost:3000/health_facilities**
**Any background context you want to provide?**
None
**What are the relevant stories?**
No data is being captured under Health facilities
**Screenshots(if appropriate)**
None
**Questions**
None